### PR TITLE
Added Follow last tab option to Terminal settings

### DIFF
--- a/src/Grids/TerminalGrid.vala
+++ b/src/Grids/TerminalGrid.vala
@@ -207,6 +207,18 @@ namespace ElementaryTweaks {
                     );
             this.add (natural_copy_paste_switch);
             
+            var follow_last_tab = new TweakWidget.with_switch (
+                        _("Follow last tab:"),
+                        _("If the user opens a new tab either take the current workdirectory of the previous tab or the default one."),
+                        null,
+                        (() => { return TerminalSettings.get_default ().follow_last_tab; }), // get
+                        ((val) => {
+                                TerminalSettings.get_default ().follow_last_tab = val;
+                            }), // set
+                        (() => { TerminalSettings.get_default ().schema.reset ("follow-last-tab"); }) // reset
+                    );
+            this.add (follow_last_tab);
+            
             var cursor_map = new Gee.HashMap<string, string> ();
             cursor_map.set ("Block", _("Block"));
             cursor_map.set ("I-Beam", _("I-Beam"));

--- a/src/Settings/TerminalSettings.vala
+++ b/src/Settings/TerminalSettings.vala
@@ -29,6 +29,7 @@ namespace ElementaryTweaks {
         public int scrollback_lines { get; set; }
         public bool unsafe_paste_alert { get; set; }
         public bool natural_copy_paste { get; set; }
+        public bool follow_last_tab { get; set; }
         public string cursor_shape { get; set; }
                 
         static TerminalSettings? instance = null;


### PR DESCRIPTION
That is one of the things I immediately wanted to change about the terminal, so it would be nice to have an easy-to-access setting for that.

I have not tested it, the way I changed it on my machine is` gsettings set org.pantheon.terminal.settings follow-last-tab true` and based on the other code I assumed that is what's necessary.