### PR TITLE
Comment out unused codes to prevent an error being displayed

### DIFF
--- a/src/Panes/AppearancePane.vala
+++ b/src/Panes/AppearancePane.vala
@@ -21,13 +21,13 @@ namespace ElementaryTweaks {
         private Gtk.Switch prefer_dark_switch;
         private Gtk.Switch gnome_menu;
         private Gtk.ComboBox gtk_combobox;
-        private Gtk.ComboBox metacity_combobox;
+        //  private Gtk.ComboBox metacity_combobox;
         private Gtk.ComboBox icon_combobox;
         private Gtk.ComboBox cursor_combobox;
         private Gtk.ComboBox controls_combobox;
 
         private Gtk.ListStore gtk_store;
-        private Gtk.ListStore metacity_store;
+        //  private Gtk.ListStore metacity_store;
         private Gtk.ListStore icon_store;
         private Gtk.ListStore cursor_store;
         private Gtk.ListStore controls_store;
@@ -82,7 +82,7 @@ namespace ElementaryTweaks {
             controls_store = AppearanceSettings.get_button_layouts (out controls_index);
 
             gtk_combobox.set_model (gtk_store);
-            metacity_combobox.set_model (metacity_store);
+            //  metacity_combobox.set_model (metacity_store);
             icon_combobox.set_model (icon_store);
             cursor_combobox.set_model (cursor_store);
             controls_combobox.set_model (controls_store);


### PR DESCRIPTION
Every time I open elementary tweaks, I get the following error:

```
(io.elementary.switchboard:11763): Gtk-CRITICAL **: 11:24:40.912: gtk_combo_box_set_model: assertion 'GTK_IS_COMBO_BOX (combo_box)' failed
```

This PR prevents that message being displayed by commenting out some codes related to an unused member.
