### PR TITLE
Slingshot: Remove size option

### DIFF
--- a/src/Panes/SlingshotPane.vala
+++ b/src/Panes/SlingshotPane.vala
@@ -20,12 +20,6 @@ namespace ElementaryTweaks {
     public class Panes.SlingshotPane : Categories.Pane {
         private Gtk.Switch category_default;
 
-        private Gtk.Adjustment rows_adj = new Gtk.Adjustment (0,1,10,1,1,1);
-        private Gtk.Adjustment columns_adj = new Gtk.Adjustment (0,3,10,1,1,1);
-
-        private Gtk.SpinButton rows;
-        private Gtk.SpinButton columns;
-
         public SlingshotPane () {
             base (_("Launcher"), "preferences-tweaks-slingshot");
         }
@@ -39,24 +33,16 @@ namespace ElementaryTweaks {
         }
 
         private void build_ui () {
-            var size_box = new Widgets.SettingsBox ();
             var category_box = new Widgets.SettingsBox ();
-
-            rows = size_box.add_spin_button (_("Rows"), rows_adj);
-            columns = size_box.add_spin_button (_("Columns"), columns_adj);
 
             category_default = category_box.add_switch (_("Show category view by default"));
 
-            grid.add (size_box);
             grid.add (category_box);
 
             grid.show_all ();
         }
 
         protected override void init_data () {
-            rows.set_value (SlingshotSettings.get_default ().rows);
-            columns.set_value (SlingshotSettings.get_default ().columns);
-
             category_default.set_state (SlingshotSettings.get_default ().use_category);
         }
 
@@ -64,9 +50,6 @@ namespace ElementaryTweaks {
              category_default.notify["active"].connect (() => {
                 SlingshotSettings.get_default ().use_category = category_default.state;
             });
-
-            connect_spin_button (rows, (val) => { SlingshotSettings.get_default ().rows = val; });
-            connect_spin_button (columns, (val) => { SlingshotSettings.get_default ().columns = val; });
 
             connect_reset_button (() => {SlingshotSettings.get_default().reset (); });
         }

--- a/src/Settings/SlingshotSettings.vala
+++ b/src/Settings/SlingshotSettings.vala
@@ -21,8 +21,6 @@ namespace ElementaryTweaks {
     public class SlingshotSettings : Granite.Services.Settings
     {
         public bool use_category { get; set; }
-        public int rows { get; set; }
-        public int columns { get; set; }
 
         static SlingshotSettings? instance = null;
 
@@ -41,8 +39,6 @@ namespace ElementaryTweaks {
 
         public void reset () {
             schema.reset ("use-category");
-            schema.reset ("rows");
-            schema.reset ("columns");
         }
     }
 }


### PR DESCRIPTION
Fixes #115

[The size configuration option was removed](https://github.com/elementary/applications-menu/commit/c0471d24f38ba3192adb50b5c5d76fe1c32635eb#diff-1483c2984b40a030cae1b018341d060a) in the latest version of Applications Menu and at the same time the keys `rows` and `columns` were removed. The Plug is working as expected in the latest Juno at the moment, but it will crash when a new version of Applications Menu is released.

Since the removal of the size configuration option was done in Applications Menu itself, the realistic solution to fix this issue is to remove this option from elementary tweaks too. To revive the option in Applications Menu would be mostly impossible.
