### PR TITLE
README: Remove libgconf2-dev from README and CMake files

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ sudo apt install software-properties-common
 
 ### How to build
 ```
-sudo apt install libgconf2-dev libpolkit-gobject-1-dev libswitchboard-2.0-dev elementary-sdk
+sudo apt install libpolkit-gobject-1-dev libswitchboard-2.0-dev elementary-sdk
 meson build --prefix=/usr
 cd build
 ninja

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,7 +1,7 @@
 find_package (PkgConfig)
 
 # Add all your dependencies to the list below
-pkg_check_modules (DEPS REQUIRED gthread-2.0 gtk+-3.0 switchboard-2.0 granite gconf-2.0 gee-0.8 polkit-gobject-1 glib-2.0)
+pkg_check_modules (DEPS REQUIRED gthread-2.0 gtk+-3.0 switchboard-2.0 granite gee-0.8 polkit-gobject-1 glib-2.0)
 
 add_definitions (${DEPS_CFLAGS})
 link_libraries (${DEPS_LIBRARIES})
@@ -46,7 +46,6 @@ PACKAGES
     gee-0.8
     switchboard-2.0
     granite
-    gconf-2.0
     polkit-gobject-1
     posix
 OPTIONS


### PR DESCRIPTION
I seem to forget removing `libgconf2-dev` from README and CMake files in #101.
