### PR TITLE
README: More easy-to-read and user-friendly installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ elementary tweaks is a system settings panel for elementary OS **Juno** that let
 [Previous Changelog](CHANGELOG.md)
 
 ## Installation
-### Install From PPA (recommended)
+### From PPA (recommended)
 If you have never added a PPA on Juno before, you might need to run this command first: 
 
 ```
@@ -29,7 +29,7 @@ sudo apt install elementary-tweaks
 
 Open System Settings and there should be a new Plug named "Tweaks".
 
-### Install From Source Code
+### From Source Code
 If you want to install from source code, clone this repository and then run the following commands:
 
 ```

--- a/README.md
+++ b/README.md
@@ -13,20 +13,27 @@ elementary tweaks is a system settings panel for elementary OS **Juno** that let
 [Previous Changelog](CHANGELOG.md)
 
 ## Installation
+### Install From PPA (recommended)
+If you have never added a PPA on Juno before, you might need to run this command first: 
+
+```
+sudo apt install software-properties-common
+```
+
+Add the PPA of elementary tweaks and then install it:
 
 ```
 sudo add-apt-repository ppa:philip.scott/elementary-tweaks
 sudo apt install elementary-tweaks
 ```
 
-If you have never added a PPA on Juno before, you might need to run this command first: 
-```
-sudo apt install software-properties-common
-```
+Open System Settings and there should be a new Plug named "Tweaks".
 
-### How to build
+### Install From Source Code
+If you want to install from source code, clone this repository and then run the following commands:
+
 ```
-sudo apt install libgconf2-dev libpolkit-gobject-1-dev libswitchboard-2.0-dev elementary-sdk
+sudo apt install libpolkit-gobject-1-dev libswitchboard-2.0-dev elementary-sdk
 meson build --prefix=/usr
 cd build
 ninja

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Open System Settings and there should be a new Plug named "Tweaks".
 If you want to install from source code, clone this repository and then run the following commands:
 
 ```
-sudo apt install libpolkit-gobject-1-dev libswitchboard-2.0-dev elementary-sdk
+sudo apt install libgconf2-dev libpolkit-gobject-1-dev libswitchboard-2.0-dev elementary-sdk
 meson build --prefix=/usr
 cd build
 ninja


### PR DESCRIPTION
Some users may run all commands―installation from both the PPA and source code―and stuck when they run `meson build --prefix=/usr` (without cloning the repository) and see the `Neither directory contains a build file meson.build` error.

(Fixes #129, Fixes #137, supersedes #125)
