### PR TITLE
Terminal: Add cursor-shape and tab-bar-position to TerminalPane

### DIFF
--- a/src/Panes/TerminalPane.vala
+++ b/src/Panes/TerminalPane.vala
@@ -25,6 +25,12 @@ namespace ElementaryTweaks {
         private Gtk.Switch rem_tabs;
         private Gtk.Switch term_bell;
 
+        private Gtk.ComboBox tab_behaviour;
+        private Gtk.ListStore tab_behaviour_store;
+
+        private Gtk.ComboBox cursor_shape;
+        private Gtk.ListStore cursor_shape_store;
+
         public TerminalPane () {
             base (_("Terminal"), "utilities-terminal");
         }
@@ -32,6 +38,7 @@ namespace ElementaryTweaks {
         construct {
             if (Util.schema_exists ("org.pantheon.terminal.settings") || Util.schema_exists ("io.elementary.terminal.settings")) {
                 build_ui ();
+                make_stores ();
                 init_data ();
                 connect_signals ();
             }
@@ -48,10 +55,20 @@ namespace ElementaryTweaks {
             unsafe_paste_alert = box.add_switch (_("Unsafe paste alert"));
             rem_tabs = box.add_switch (_("Remember tabs"));
             term_bell = box.add_switch (_("Terminal bell"));
+            cursor_shape = box.add_combo_box (_("Cursor shape"));
+            tab_behaviour = box.add_combo_box (_("Tabs behaviour"));
 
             grid.add (box);
 
             grid.show_all ();
+        }
+
+        private void make_stores () {
+            int cursor_shape_index;
+            cursor_shape_store = TerminalSettings.get_cursor_shapes (out cursor_shape_index);
+
+            int behaviour_index;
+            tab_behaviour_store = TerminalSettings.get_tab_behaviours (out behaviour_index);
         }
 
         protected override void init_data () {
@@ -64,6 +81,16 @@ namespace ElementaryTweaks {
             unsafe_paste_alert.set_state (TerminalSettings.get_default ().unsafe_paste_alert);
             rem_tabs.set_state (TerminalSettings.get_default ().remember_tabs);
             term_bell.set_state (TerminalSettings.get_default ().audible_bell);
+
+            int cursor_shape_index;
+            TerminalSettings.get_cursor_shapes (out cursor_shape_index);
+            cursor_shape.set_model (cursor_shape_store);
+            cursor_shape.set_active (cursor_shape_index);
+
+            int behaviour_index;
+            TerminalSettings.get_tab_behaviours (out behaviour_index);
+            tab_behaviour.set_model (tab_behaviour_store);
+            tab_behaviour.set_active (behaviour_index);
         }
 
         private void connect_signals () {
@@ -89,6 +116,14 @@ namespace ElementaryTweaks {
 
             term_bell.notify["active"].connect (() => {
                 TerminalSettings.get_default ().audible_bell = term_bell.state;
+            });
+
+            connect_combobox (tab_behaviour, tab_behaviour_store, (val) => {
+                TerminalSettings.get_default ().tab_bar_behavior = val;
+            });
+
+            connect_combobox (cursor_shape, cursor_shape_store, (val) => {
+                TerminalSettings.get_default ().cursor_shape = val;
             });
 
             connect_reset_button (() => {TerminalSettings.get_default ().reset();});

--- a/src/Settings/TerminalSettings.vala
+++ b/src/Settings/TerminalSettings.vala
@@ -32,6 +32,7 @@ namespace ElementaryTweaks {
         public bool audible_bell { get; set; }
         public bool remember_tabs { get; set; }
         public string cursor_shape { get; set; }
+        public string tab_bar_behavior { get; set; }
                 
         static TerminalSettings? instance = null;
 
@@ -46,9 +47,60 @@ namespace ElementaryTweaks {
             return instance;
         }
 
+        public static Gtk.ListStore get_cursor_shapes (out int active_index) {
+            var shape_layouts = new Gtk.ListStore(2, typeof (string), typeof (string));
+            Gtk.TreeIter iter;
+
+            int index = 0;
+            active_index = 0;
+
+            var shapes_map = new Gee.HashMap<string, string> ();
+            shapes_map.set ("Block", _("Block"));
+            shapes_map.set ("I-Beam", _("I-Beam"));
+            shapes_map.set ("Underline", _("Underline"));
+
+            foreach (var layout in shapes_map.entries) {
+                shape_layouts.append (out iter);
+                shape_layouts.set (iter, 0, layout.value, 1, layout.key);
+                if (TerminalSettings.get_default ().tab_bar_behavior == layout.key) {
+                    active_index = index;
+                }
+
+                index++;
+            }
+
+            return shape_layouts;
+        }
+
+        public static Gtk.ListStore get_tab_behaviours (out int active_index) {
+            var behaviour_layouts = new Gtk.ListStore(2, typeof (string), typeof (string));
+            Gtk.TreeIter iter;
+
+            int index = 0;
+            active_index = 0;
+
+            var behaviour_map = new Gee.HashMap<string, string> ();
+            behaviour_map.set ("Always Show Tabs", _("Always Show Tabs"));
+            behaviour_map.set ("Hide When Single Tab", _("Hide When Single Tab"));
+            behaviour_map.set ("Never Show Tabs", _("Never Show Tabs"));
+
+            foreach (var layout in behaviour_map.entries) {
+                behaviour_layouts.append (out iter);
+                behaviour_layouts.set (iter, 0, layout.value, 1, layout.key);
+                if (TerminalSettings.get_default ().cursor_shape == layout.key) {
+                    active_index = index;
+                }
+
+                index++;
+            }
+
+            return behaviour_layouts;
+        }
+
         public void reset () {
             string[] to_reset = {"background", "cursor-color", "font", "foreground", "palette",
                                  "scrollback-lines", "unsafe-paste-alert", "natural-copy-paste",
+                                 "tab-bar-behaviour",
                                  "follow-last-tab", "cursor-shape", "audible-bell", "remember-tabs"};
 
             foreach (string key in to_reset) {


### PR DESCRIPTION
Add comboboxes to TerminalPane to control both 'cursor-shape' and 'tab-bar-position' setting.

![imagen](https://user-images.githubusercontent.com/11801/80716467-f6c6cb80-8af7-11ea-9ff3-a09c636cb74f.png)
