### PR TITLE
More descriptive label for dark style

### DIFF
--- a/src/Panes/AppearancePane.vala
+++ b/src/Panes/AppearancePane.vala
@@ -57,7 +57,7 @@ namespace ElementaryTweaks {
             //metacity_combobox = theme_box.add_combo_box (_("Metacity (Non-GTK+ applications)"));
             icon_combobox = theme_box.add_combo_box (_("Icons"));
             cursor_combobox = theme_box.add_combo_box (_("Cursor"));
-            prefer_dark_switch = theme_box.add_switch (_("Force all apps to use dark style"));
+            prefer_dark_switch = theme_box.add_switch (_("Force third-party apps to use dark style"));
 
             grid.add (theme_label);
             grid.add (theme_box);

--- a/src/Panes/AppearancePane.vala
+++ b/src/Panes/AppearancePane.vala
@@ -57,7 +57,7 @@ namespace ElementaryTweaks {
             //metacity_combobox = theme_box.add_combo_box (_("Metacity (Non-GTK+ applications)"));
             icon_combobox = theme_box.add_combo_box (_("Icons"));
             cursor_combobox = theme_box.add_combo_box (_("Cursor"));
-            prefer_dark_switch = theme_box.add_switch (_("Prefer dark variant"));
+            prefer_dark_switch = theme_box.add_switch (_("Force all apps to use dark style"));
 
             grid.add (theme_label);
             grid.add (theme_box);


### PR DESCRIPTION
Related to #146

elementary OS will support an OS-wide dark preference, but this only works for apps that can detect this preference using `Granite.Settings.prefers_color_schema`; Third-party apps like Google Chrome, Slack, or Visual Studio Code are not switched to dark style according to this preference, and we still need to enable "Prefer dark variant" switch in elementary Tweaks to force these apps to use dark style.

However, I think the current label of this switch might be confusing, so I changed the label string.
